### PR TITLE
Add deployment doc links to readme file

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ Student repository for the web development bootcamp [location]-web-[year]-[cours
 
 - [Guide how to clone this repository](/docs/install-manual-en.md)
 
+## Rules
+
+- [Bootcamp Information](./docs/bootcamp-info-en.md)
+- [Bootcamp Rules](./docs/bootcamp-rules-en.md)
+
+## Deployment Instructions
+
+- [Github Pages](./docs/deployment-github-pages.md)
+- [Vercel](./docs/deployment-vercel.md)
+
+## Challenges Workflow
+
+[Here](./docs/challenge-workflow.md) you can find the challenge workflow.  
+
 ---
 
 ## Session Overview

--- a/SP_README.md
+++ b/SP_README.md
@@ -18,6 +18,17 @@ Student repository for the web development bootcamp [cohort-Name]-web--[year].
 - [Bootcamp Information](./docs/bootcamp-info-en.md)
 - [Bootcamp Rules](./docs/bootcamp-rules-en.md)
 
+## Deployment Instructions
+
+- [Github Pages](./docs/deployment-github-pages.md)
+- [Vercel](./docs/deployment-vercel.md)
+
+## Challenges Workflow
+
+[Here](./docs/challenge-workflow.md) you can find the challenge workflow.  
+
+Remember to review someone else’s PR after submitting your own. Collaboration and feedback are key!  
+
 ---
 
 ## Session Overview


### PR DESCRIPTION
Due to what we talked in one of the meeting regarding the links to the instructions to how to deploy the projects, I added them in the Readme file. 
If I am not mistaken we decided that it was a good idea to added to the Readme file of the cohort template.
I added too the link to the challenge workflow. For Spiced Readme, take in mind that the files will be rename without the prefix `SP_`